### PR TITLE
Updated some code due to the 'Breaking Changes' introduced in 0.3.0 release

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route_tutorial/pages/initial_page.dart';
 import 'package:auto_route_tutorial/routes/router.gr.dart';
 import 'package:flutter/material.dart';
 
@@ -11,7 +10,7 @@ class MyApp extends StatelessWidget {
       title: 'Material App',
       initialRoute: Router.initialPage,
       onGenerateRoute: Router.onGenerateRoute,
-      navigatorKey: Router.navigatorKey,
+      navigatorKey: Router.navigator.key,
     );
   }
 }

--- a/lib/routes/router.dart
+++ b/lib/routes/router.dart
@@ -1,10 +1,10 @@
 import 'package:auto_route/auto_route_annotations.dart';
-import 'package:auto_route/transitions_builders.dart';
 import 'package:auto_route_tutorial/pages/initial_page.dart';
 import 'package:auto_route_tutorial/pages/second_page.dart';
 import 'package:auto_route_tutorial/pages/third_page.dart';
+import 'package:auto_route/auto_route.dart';
 
-@autoRouter
+@MaterialAutoRouter()
 class $Router {
   @initial
   InitialPage initialPage;

--- a/lib/routes/router.gr.dart
+++ b/lib/routes/router.gr.dart
@@ -6,25 +6,21 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:auto_route/router_utils.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:auto_route_tutorial/pages/initial_page.dart';
 import 'package:auto_route_tutorial/pages/second_page.dart';
 import 'package:auto_route_tutorial/pages/third_page.dart';
-import 'package:auto_route/transitions_builders.dart';
 
 class Router {
   static const initialPage = '/';
-  static const secondPage = '/secondPage';
-  static const thirdPage = '/thirdPage';
-  static GlobalKey<NavigatorState> get navigatorKey =>
-      getNavigatorKey<Router>();
-  static NavigatorState get navigator => navigatorKey.currentState;
-
+  static const secondPage = '/second-page';
+  static const thirdPage = '/third-page';
+  static final navigator = ExtendedNavigator();
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     final args = settings.arguments;
     switch (settings.name) {
       case Router.initialPage:
-        return MaterialPageRoute(
+        return MaterialPageRoute<dynamic>(
           builder: (_) => InitialPage(),
           settings: settings,
         );
@@ -33,7 +29,7 @@ class Router {
           return misTypedArgsRoute<String>(args);
         }
         final typedArgs = args as String;
-        return MaterialPageRoute(
+        return MaterialPageRoute<dynamic>(
           builder: (_) => SecondPage(userId: typedArgs),
           settings: settings,
           fullscreenDialog: true,
@@ -43,7 +39,7 @@ class Router {
           return misTypedArgsRoute<ThirdPageArguments>(args);
         }
         final typedArgs = args as ThirdPageArguments;
-        return PageRouteBuilder(
+        return PageRouteBuilder<dynamic>(
           pageBuilder: (ctx, animation, secondaryAnimation) =>
               ThirdPage(userName: typedArgs.userName, points: typedArgs.points),
           settings: settings,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: auto_route
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.1"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+3"
+    version: "0.3.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  auto_route: ^0.2.1
+  auto_route: ^0.3.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner:
-  auto_route_generator: ^0.2.1+3
+  auto_route_generator: ^0.3.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Because of the "Breaking Changes" introduced in auto_route 0.3.0 release. Some parts of the code has to be modified for this project to work on the current (March 2020) version of auto_route library

Details of these change as follows:

- Add global route customization Use MaterialAutoRouter, CupertinoAutoRouter or CustomAutoRouter instead of AutoRouter
- Navigator key is now accessed by calling Router.navigator.key instead of Router.navigatorKey.
- Add Route guards
- Add optional returnType param in all AutoRoute types.
- Remove generate Navigator Key optional.
- Fix generate error when using dynamic vars in route widget constructors